### PR TITLE
Fix entityManager.merge does not set null value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY configuration/mariadb/mariadb-java-client-3.3.3.jar $CATALINA_HOME/lib/
 EXPOSE 8080
 
 # Environment variable for Java options, include serialization configs
-ENV JAVA_OPTS="-Dtomee.serialization.class.blacklist=- -Dtomee.serialization.class.whitelist=* -Dispyb.properties=file:///etc/ispyb/ispyb.properties -Dtomee.jaxws.subcontext=/ispybWS"
+ENV JAVA_OPTS="-Dtomee.serialization.class.blacklist=- -Dtomee.serialization.class.whitelist=* -Dispyb.properties=file:///etc/ispyb/ispyb.properties -Dtomee.jaxws.subcontext=/ispybWS -Dopenejb.localcopy=false"
 
 # Start Tomcat server
 CMD ["catalina.sh", "run"]

--- a/ispyb-ejb/src/test/java/ispyb/server/common/services/shipping/Container3ServiceBeanTest.java
+++ b/ispyb-ejb/src/test/java/ispyb/server/common/services/shipping/Container3ServiceBeanTest.java
@@ -2,9 +2,11 @@ package ispyb.server.common.services.shipping;
 
 import ispyb.TestBase;
 import jakarta.inject.Inject;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class Container3ServiceBeanTest extends TestBase {
 
@@ -15,6 +17,16 @@ public class Container3ServiceBeanTest extends TestBase {
     public void findByPk() throws Exception {
         var result = service.findByPk(13, false);
         assertNotNull(result);
+    }
+
+    @Ignore("Requires db to be up and running")
+    @Test
+    public void testUpdate_setNull() throws Exception {
+        var vo = service.findByPk(13, false);
+        vo.setSampleChangerLocation(null);
+        var result = service.update(vo);
+        assertNotNull(result);
+        assertNull(result.getSampleChangerLocation());
     }
 
 }


### PR DESCRIPTION
This fixes the issues with `entityManager.merge` ignoring the `null` values in e.g. `ContainerServiceBean`